### PR TITLE
Enable Ltrees to be selected and inserted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # diesel_ltree [![Build Status](https://travis-ci.org/kivikakk/diesel_ltree.svg?branch=master)](https://travis-ci.org/kivikakk/diesel_ltree) [![crates.io version](https://img.shields.io/crates/v/diesel_ltree.svg)](https://crates.io/crates/diesel_ltree)
 
 Adds support for the `ltree` PostgreSQL extension type to Diesel, supporting all functions and operators thereon.
+
+## A note about `Insertable` and Postgres Ltree binary protocol support
+
+Binary protocol support for Ltrees (has been committed)[https://commitfest.postgresql.org/24/2242/], but not released as of 2020.04.29. As such, the only option for Diesel, which uses the Postgres binary protocol (likewise for rust_postgres), is to treat the transmittion of Ltrees as Postgres `text`, until this commit goes live. This crate currently transmits Ltree paths as `text`, then casts them to `ltree`.
+

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ Adds support for the `ltree` PostgreSQL extension type to Diesel, supporting all
 
 Binary protocol support for Ltrees (has been committed)[https://commitfest.postgresql.org/24/2242/], but not released as of 2020.04.29. As such, the only option for Diesel, which uses the Postgres binary protocol (likewise for rust_postgres), is to treat the transmittion of Ltrees as Postgres `text`, until this commit goes live. This crate currently transmits Ltree paths as `text`, then casts them to `ltree`.
 
+## Selecting Ltrees
+
+Until binary protocol support is added for Ltrees, you need to select `ltree2text(my_tree)`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,40 +5,43 @@ extern crate diesel;
 mod tests;
 
 mod types {
-    use diesel::pg::{Pg, PgMetadataLookup, PgTypeMetadata};
-    use diesel::types::HasSqlType;
+    use diesel::query_builder::*;
+    use diesel::*;
 
-    #[derive(Clone, Copy, QueryId)]
-    pub struct Ltree;
+    #[derive(SqlType, QueryId, FromSqlRow, Clone, Debug, PartialEq)]
+    #[postgres(type_name = "text")]
+    pub struct Ltree(pub String);
 
-    impl HasSqlType<Ltree> for Pg {
-        fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
-            lookup.lookup_type("ltree")
-        }
+    impl Expression for Ltree {
+        type SqlType = Ltree;
     }
 
-    #[derive(Clone, Copy, QueryId)]
+    impl<DB> QueryFragment<DB> for Ltree
+    where
+        DB: diesel::backend::Backend,
+    {
+        fn walk_ast(&self, mut out: AstPass<DB>) -> QueryResult<()> {
+            out.push_bind_param::<diesel::sql_types::Text, _>(&self.0)?;
+            out.push_sql(&"::text::ltree"); // cast the text to an ltree in the query, so that the client can sent the ltree as text
+            Ok(())
+        }
+    }
+    impl<QS> SelectableExpression<QS> for Ltree {}
+    impl<QS> AppearsOnTable<QS> for Ltree {}
+    impl diesel::expression::NonAggregate for Ltree {}
+
+    #[derive(SqlType, Clone, Copy, QueryId)]
+    #[postgres(type_name = "lquery")]
     pub struct Lquery;
 
-    impl HasSqlType<Lquery> for Pg {
-        fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
-            lookup.lookup_type("lquery")
-        }
-    }
-
-    #[derive(Clone, Copy, QueryId)]
+    #[derive(SqlType, Clone, Copy, QueryId)]
+    #[postgres(type_name = "ltxtquery")]
     pub struct Ltxtquery;
-
-    impl HasSqlType<Ltxtquery> for Pg {
-        fn metadata(lookup: &PgMetadataLookup) -> PgTypeMetadata {
-            lookup.lookup_type("ltxtquery")
-        }
-    }
 }
 
 mod functions {
-    use types::*;
     use diesel::sql_types::*;
+    use types::*;
 
     sql_function!(fn subltree(ltree: Ltree, start: Int4, end: Int4) -> Ltree);
     sql_function!(fn subpath(ltree: Ltree, offset: Int4, len: Int4) -> Ltree);
@@ -55,14 +58,13 @@ mod functions {
 }
 
 mod dsl {
-    use types::*;
     use diesel::expression::{AsExpression, Expression};
-    use diesel::types::SingleValue;
     use diesel::sql_types::Array;
+    use types::*;
 
     mod predicates {
-        use types::*;
         use diesel::pg::Pg;
+        use types::*;
 
         diesel_infix_operator!(Contains, " @> ", backend: Pg);
         diesel_infix_operator!(ContainedBy, " <@ ", backend: Pg);
@@ -77,8 +79,6 @@ mod dsl {
     }
 
     use self::predicates::*;
-
-    impl SingleValue for Ltree {}
 
     pub trait LtreeExtensions: Expression<SqlType = Ltree> + Sized {
         fn contains<T: AsExpression<Ltree>>(self, other: T) -> Contains<Self, T::Expression> {
@@ -231,6 +231,6 @@ mod dsl {
     impl<T: Expression<SqlType = Ltxtquery>> LtxtqueryExtensions for T {}
 }
 
-pub use self::types::*;
-pub use self::functions::*;
 pub use self::dsl::*;
+pub use self::functions::*;
+pub use self::types::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,17 @@ mod types {
         type SqlType = Ltree;
     }
 
+    impl<ST, DB> diesel::types::FromSql<ST, DB> for Ltree
+    where
+        String: diesel::types::FromSql<ST, DB>,
+        DB: diesel::backend::Backend,
+        DB: diesel::types::HasSqlType<ST>,
+    {
+        fn from_sql(raw: Option<&DB::RawValue>) -> deserialize::Result<Self> {
+            diesel::types::FromSql::<ST, DB>::from_sql(raw).map(Ltree)
+        }
+    }
+
     impl<DB> QueryFragment<DB> for Ltree
     where
         DB: diesel::backend::Backend,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,6 +34,38 @@ fn get_connection() -> PgConnection {
     PgConnection::establish(&database_url).expect("Error connecting to TEST_DATABASE_URL")
 }
 
+// Uncomment this test AFTER postgres adds binary protocol support for Ltree
+// since, until then, we MUST instead transmit via the Text protocol
+// #[test]
+// fn base_operations_without_converting_to_text_first() {
+//     let connection = get_connection();
+//
+//     let results = my_tree::table
+//         .select((my_tree::id, my_tree::path))
+//         .filter(
+//             my_tree::path
+//                 .contained_by(text2ltree("root.eukaryota.plantae"))
+//                 .or(my_tree::path.contains(text2ltree("root.bacteria"))),
+//         )
+//         .order(my_tree::id)
+//         .load::<MyTree>(&connection)
+//         .unwrap()
+//         .into_iter()
+//         .map(|t| t.path)
+//         .collect::<Vec<_>>();
+//
+//     assert_eq!(
+//         results,
+//         [
+//             Ltree("root".to_string()),
+//             Ltree("root.bacteria".to_string()),
+//             Ltree("root.eukaryota.plantae".to_string()),
+//             Ltree("root.eukaryota.plantae.nematophyta".to_string()),
+//             Ltree("root.eukaryota.plantae.chlorophyta".to_string())
+//         ]
+//     );
+// }
+
 #[test]
 fn base_operations() {
     let connection = get_connection();
@@ -203,18 +235,3 @@ fn operators() {
     .get_result::<(String, String)>(&connection);
     assert_eq!(result, Ok(("a".into(), "a.b.c".into())));
 }
-
-// #[test]
-// fn does_roundtrip() {
-//     let connection = get_connection();
-//     let obj = MyEntity { id: MyId("WooHoo".into()), val: 1 };
-//
-//     diesel::insert_into(my_entities::table)
-//         .values(&obj)
-//         .execute(&connection)
-//         .expect("Couldn't insert struct into my_entities");
-//
-//     let found: Vec<MyEntity> = my_entities::table.load(&connection).unwrap();
-//     println!("found: {:?}", found);
-//     assert_eq!(found[0], obj);
-// }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,13 +1,15 @@
 extern crate dotenv;
 
-use diesel::select;
-use diesel::prelude::*;
+use super::{
+    index, lca, lquery, ltree2text, ltxtquery, nlevel, subltree, subpath, text2ltree,
+    LqueryArrayExtensions, LqueryExtensions, Ltree, LtreeArrayExtensions, LtreeExtensions,
+    LtxtqueryExtensions,
+};
 use diesel::dsl::array;
 use diesel::pg::PgConnection;
+use diesel::prelude::*;
+use diesel::select;
 use std::env;
-use super::{index, lca, lquery, ltxtquery, nlevel, subltree, subpath, LqueryArrayExtensions,
-            LqueryExtensions, Ltree, LtreeArrayExtensions, LtreeExtensions, LtxtqueryExtensions,
-            ltree2text, text2ltree};
 
 table! {
     use super::Ltree;
@@ -22,7 +24,7 @@ table! {
 #[derive(Queryable, Debug)]
 struct MyTree {
     pub id: i32,
-    pub path: String,
+    pub path: Ltree,
 }
 
 fn get_connection() -> PgConnection {
@@ -53,11 +55,11 @@ fn base_operations() {
     assert_eq!(
         results,
         [
-            "root",
-            "root.bacteria",
-            "root.eukaryota.plantae",
-            "root.eukaryota.plantae.nematophyta",
-            "root.eukaryota.plantae.chlorophyta"
+            Ltree("root".to_string()),
+            Ltree("root.bacteria".to_string()),
+            Ltree("root.eukaryota.plantae".to_string()),
+            Ltree("root.eukaryota.plantae.nematophyta".to_string()),
+            Ltree("root.eukaryota.plantae.chlorophyta".to_string())
         ]
     );
 }
@@ -81,13 +83,15 @@ fn functions() {
         text2ltree("0.1.2.3.5.4.5.6.8.5.6.8"),
         text2ltree("5.6"),
         0,
-    )).get_result::<i32>(&connection);
+    ))
+    .get_result::<i32>(&connection);
     assert_eq!(result, Ok(6));
 
     let result = select(ltree2text(lca(array((
         text2ltree("1.2.2.3"),
         text2ltree("1.2.3"),
-    ))))).get_result::<String>(&connection);
+    )))))
+    .get_result::<String>(&connection);
     assert_eq!(result, Ok("1.2".into()));
 }
 
@@ -100,7 +104,8 @@ fn operators() {
         text2ltree("1.1").eq(text2ltree("1.1")),
         text2ltree("1.1").ne(text2ltree("1.2")),
         text2ltree("1.1").ne(text2ltree("1.1")),
-    )).get_result::<(bool, bool, bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool, bool, bool)>(&connection);
     assert_eq!(result, Ok((false, true, true, false)));
 
     let result = select((
@@ -108,7 +113,8 @@ fn operators() {
         text2ltree("1.2").gt(text2ltree("1.1")),
         text2ltree("1.2").le(text2ltree("1.1")),
         text2ltree("1.2.1").ge(text2ltree("1.2")),
-    )).get_result::<(bool, bool, bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool, bool, bool)>(&connection);
     assert_eq!(result, Ok((true, true, false, true)));
 
     let result = select((
@@ -116,19 +122,22 @@ fn operators() {
         text2ltree("foo_barbaz").matches(lquery("foo_bar%")),
         lquery("foo_bar%*").matches(text2ltree("foo1_bar2_baz")),
         lquery("foo_bar%*").matches(text2ltree("foo1_br2_baz")),
-    )).get_result::<(bool, bool, bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool, bool, bool)>(&connection);
     assert_eq!(result, Ok((true, false, true, false)));
 
     let result = select((
         text2ltree("foo_bar_baz").matches_any(array((lquery("foo_bar%"), lquery("foo_bat%")))),
         text2ltree("foo_bar_baz").matches_any(array((lquery("foo_bat%"),))),
-    )).get_result::<(bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool)>(&connection);
     assert_eq!(result, Ok((true, false)));
 
     let result = select((
         array((lquery("foo_bar%"), lquery("foo_bat%"))).any_matches(text2ltree("foo_bar_baz")),
         array((lquery("foo_bat%"),)).any_matches(text2ltree("foo_bar_baz")),
-    )).get_result::<(bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool)>(&connection);
     assert_eq!(result, Ok((true, false)));
 
     let q = ltxtquery("Europe & Russia*@ & !Transportation");
@@ -136,7 +145,8 @@ fn operators() {
         text2ltree("Russian.Hello.Europe").tmatches(q),
         q.tmatches(text2ltree("Europe.russia.Transportation")),
         q.tmatches(text2ltree("russians.today.Europe")),
-    )).get_result::<(bool, bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool, bool)>(&connection);
     assert_eq!(result, Ok((true, false, true)));
 
     let result = select(ltree2text(text2ltree("a.b").concat(text2ltree("c.d"))))
@@ -148,13 +158,15 @@ fn operators() {
         array((text2ltree("a"), text2ltree("a.b.c"))).any_contains(text2ltree("a.b")),
         text2ltree("a.b").contains_any(array((text2ltree("a"), text2ltree("a.b.c")))),
         array((text2ltree("a"), text2ltree("a.b.c"))).any_contained_by(text2ltree("a.b")),
-    )).get_result::<(bool, bool, bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool, bool, bool)>(&connection);
     assert_eq!(result, Ok((true, true, true, true)));
 
     let result = select((
         array((text2ltree("a"), text2ltree("a.b"))).any_matches(lquery("a%")),
         lquery("a%").matches_any(array((text2ltree("a"), text2ltree("a.b")))),
-    )).get_result::<(bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool)>(&connection);
     assert_eq!(result, Ok((true, true)));
 
     let result = select((
@@ -162,13 +174,15 @@ fn operators() {
             .any_matches_any(array((lquery("a%"), lquery("b%")))),
         array((lquery("a%"), lquery("b%")))
             .any_matches_any(array((text2ltree("a"), text2ltree("a.b")))),
-    )).get_result::<(bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool)>(&connection);
     assert_eq!(result, Ok((true, true)));
 
     let result = select((
         array((text2ltree("a"), text2ltree("a.b"))).any_tmatches(ltxtquery("a")),
         ltxtquery("a").tmatches_any(array((text2ltree("a"), text2ltree("a.b")))),
-    )).get_result::<(bool, bool)>(&connection);
+    ))
+    .get_result::<(bool, bool)>(&connection);
     assert_eq!(result, Ok((true, true)));
 
     let result = select((
@@ -176,7 +190,8 @@ fn operators() {
         ltree2text(
             array((text2ltree("a"), text2ltree("a.b.c"))).first_contained_by(text2ltree("a.b")),
         ),
-    )).get_result::<(String, String)>(&connection);
+    ))
+    .get_result::<(String, String)>(&connection);
     assert_eq!(result, Ok(("a".into(), "a.b.c".into())));
 
     let result = select((
@@ -184,6 +199,22 @@ fn operators() {
         ltree2text(
             array((text2ltree("a"), text2ltree("a.b.c"))).first_tmatches(ltxtquery("a & b")),
         ),
-    )).get_result::<(String, String)>(&connection);
+    ))
+    .get_result::<(String, String)>(&connection);
     assert_eq!(result, Ok(("a".into(), "a.b.c".into())));
 }
+
+// #[test]
+// fn does_roundtrip() {
+//     let connection = get_connection();
+//     let obj = MyEntity { id: MyId("WooHoo".into()), val: 1 };
+//
+//     diesel::insert_into(my_entities::table)
+//         .values(&obj)
+//         .execute(&connection)
+//         .expect("Couldn't insert struct into my_entities");
+//
+//     let found: Vec<MyEntity> = my_entities::table.load(&connection).unwrap();
+//     println!("found: {:?}", found);
+//     assert_eq!(found[0], obj);
+// }


### PR DESCRIPTION
Adds support for Ltrees to be selected and inserted. Note that Postgres has not yet added binary protocol support for Ltrees yet, so this needs to transmit Ltrees as text.