### PR TITLE
Remove useless build dependencies and update dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,6 @@ repository = "https://github.com/kivikakk/diesel_ltree"
 [dependencies]
 diesel = { version = "1.0", features = ["postgres"] }
 
-[build-dependencies]
-dotenv = "0.10"
-diesel = { version = "1.0", features = ["postgres"] }
-
 [dev-dependencies]
-dotenv = "0.10"
+dotenv = "0.15"
 diesel_migrations = "1.0"


### PR DESCRIPTION
Hello, I'm back at trying to use this crate after my first attempt with #7. I noticed this crate has build-dependencies, which aren't necessary at all, so I removed them. While at it I upgraded `dotenv`, since 0.10 is a very antique version