### PR TITLE
Move away from deprecated diesel re-exports and disable default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 repository = "https://github.com/kivikakk/diesel_ltree"
 
 [dependencies]
-diesel = { version = "1.4", features = ["postgres"] }
+diesel = { version = "1.4", default-features = false, features = ["postgres"] }
 
 [dev-dependencies]
 dotenv = "0.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ readme = "README.md"
 repository = "https://github.com/kivikakk/diesel_ltree"
 
 [dependencies]
-diesel = { version = "1.0", features = ["postgres"] }
+diesel = { version = "1.4", features = ["postgres"] }
 
 [dev-dependencies]
 dotenv = "0.15"
-diesel_migrations = "1.0"
+diesel_migrations = "1.4"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@ mod types {
     //     }
     // }
 
-    impl<DB> diesel::types::FromSql<diesel::sql_types::Text, DB> for Ltree
+    impl<DB> diesel::deserialize::FromSql<diesel::sql_types::Text, DB> for Ltree
     where
-        String: diesel::types::FromSql<Text, DB>,
+        String: diesel::deserialize::FromSql<Text, DB>,
         DB: diesel::backend::Backend,
-        DB: diesel::types::HasSqlType<Text>,
+        DB: diesel::sql_types::HasSqlType<Text>,
     {
         fn from_sql(raw: Option<&DB::RawValue>) -> deserialize::Result<Self> {
             String::from_sql(raw).map(Ltree)


### PR DESCRIPTION
* Moves away from re-exports deprecated in diesel 1.4
* Bumps the version in Cargo.toml, in order to stop users from using older diesel versions, which wouldn't work
* Disables default features, making diesel faster to compile