### PR TITLE
Enable binary protocol support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
   - diesel database setup
 
 addons:
-  postgresql: "9.5"
+  postgresql: "13"
 
 matrix:
   fast_finish: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 repository = "https://github.com/kivikakk/diesel_ltree"
 
 [dependencies]
+byteorder = "1.0"
 diesel = { version = "1.4", default-features = false, features = ["postgres"] }
 
 [dev-dependencies]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -34,37 +34,35 @@ fn get_connection() -> PgConnection {
     PgConnection::establish(&database_url).expect("Error connecting to TEST_DATABASE_URL")
 }
 
-// Uncomment this test AFTER postgres adds binary protocol support for Ltree
-// since, until then, we MUST instead transmit via the Text protocol
-// #[test]
-// fn base_operations_without_converting_to_text_first() {
-//     let connection = get_connection();
-//
-//     let results = my_tree::table
-//         .select((my_tree::id, my_tree::path))
-//         .filter(
-//             my_tree::path
-//                 .contained_by(text2ltree("root.eukaryota.plantae"))
-//                 .or(my_tree::path.contains(text2ltree("root.bacteria"))),
-//         )
-//         .order(my_tree::id)
-//         .load::<MyTree>(&connection)
-//         .unwrap()
-//         .into_iter()
-//         .map(|t| t.path)
-//         .collect::<Vec<_>>();
-//
-//     assert_eq!(
-//         results,
-//         [
-//             Ltree("root".to_string()),
-//             Ltree("root.bacteria".to_string()),
-//             Ltree("root.eukaryota.plantae".to_string()),
-//             Ltree("root.eukaryota.plantae.nematophyta".to_string()),
-//             Ltree("root.eukaryota.plantae.chlorophyta".to_string())
-//         ]
-//     );
-// }
+#[test]
+fn base_operations_without_converting_to_text_first() {
+    let connection = get_connection();
+
+    let results = my_tree::table
+        .select((my_tree::id, my_tree::path))
+        .filter(
+            my_tree::path
+                .contained_by(text2ltree("root.eukaryota.plantae"))
+                .or(my_tree::path.contains(text2ltree("root.bacteria"))),
+        )
+        .order(my_tree::id)
+        .load::<MyTree>(&connection)
+        .unwrap()
+        .into_iter()
+        .map(|t| t.path)
+        .collect::<Vec<_>>();
+
+    assert_eq!(
+        results,
+        [
+            Ltree("root".to_string()),
+            Ltree("root.bacteria".to_string()),
+            Ltree("root.eukaryota.plantae".to_string()),
+            Ltree("root.eukaryota.plantae.nematophyta".to_string()),
+            Ltree("root.eukaryota.plantae.chlorophyta".to_string())
+        ]
+    );
+}
 
 #[test]
 fn base_operations() {


### PR DESCRIPTION
Hi,

Would be keen to hear feedback on this, but it looks like binary protocol support can be enabled now, so this PR might be wanted? I'm not sure about adding an extra dependency, but there didn't seem to be an obvious way to handle the version number.

---

Enable binary protocol support which is stable from Postgresql > 13,
enabling associated tests.

Removes the cast to text for ltrees and enables from FromSQL instance.

Specializes the FromSQL instance for Postgresql to enable reading the
version number of the protocol, including a debug_assert to check that
the version is compatible.

Updates travis CI to work with a compatible Postgresql version.