### PR TITLE
tests: run each test in a transaction; don't commit

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -35,7 +35,9 @@ fn get_connection() -> PgConnection {
     dotenv::dotenv().ok();
 
     let database_url = env::var("TEST_DATABASE_URL").expect("TEST_DATABASE_URL must be set");
-    PgConnection::establish(&database_url).expect("Error connecting to TEST_DATABASE_URL")
+    let mut connection = PgConnection::establish(&database_url).expect("Error connecting to TEST_DATABASE_URL");
+    connection.begin_test_transaction().expect("couldn't begin test transaction");
+    connection
 }
 
 #[test]


### PR DESCRIPTION
To not influence other tests, either parallel during or after.