### PR TITLE
disable generate missing sql types in example

### DIFF
--- a/diesel.toml
+++ b/diesel.toml
@@ -5,3 +5,4 @@ patch_file = "src/tests/schema.patch"
 import_types = ["diesel::sql_types::*", "crate::sql_types::*"]
 # For diesel_ltree users wishing to use print_schema, you'll want something like this instead:
 # import_types = ["diesel::sql_types::*", "diesel_ltree::sql_types::*"]
+# generate_missing_sql_type_definitions = false


### PR DESCRIPTION
for correct diesel schema.rs generation