### PR TITLE
Remove dependency on `pq-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ repository = "https://github.com/kivikakk/diesel_ltree"
 
 [dependencies]
 byteorder = "1.0"
-diesel = { version = "2.0", default-features = false, features = ["postgres"] }
+diesel = { version = "2.0", default-features = false, features = [
+    "postgres_backend",
+] }
 
 [dev-dependencies]
 dotenv = "0.15"
+diesel = { version = "2.0", default-features = false, features = ["postgres"] }
 diesel_migrations = "2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,9 @@ pub mod values {
         DB: diesel::backend::Backend,
         DB: diesel::sql_types::HasSqlType<crate::sql_types::Ltree>,
     {
-        fn from_sql(bytes: diesel::backend::RawValue<'_, DB>) -> deserialize::Result<Self> {
+        fn from_sql(
+            bytes: <DB as diesel::backend::Backend>::RawValue<'_>,
+        ) -> deserialize::Result<Self> {
             String::from_sql(bytes).map(Ltree)
         }
     }


### PR DESCRIPTION
Using the `postgres` feature of Diesel unnecessarily introduces a dependency on `pq-sys` which is annoying for projects that use `diesel-async` that doesn't have a dependency on the native C driver for PostgreSQL.

This PR removes this dependency by using `postgres_backend`, which exposes the same types minus the connection implementation.

It also fixes a (spurious) error which occurs because the `with-deprecated` feature is disabled

(This is theoretically a semver breaking change)